### PR TITLE
prepare new panel registry

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -22,6 +22,7 @@
   ],
   "globals": {
     "unused": false,
+    "deprecate": false,
     "Editor": false,
     "Helper": false,
     "Polymer": false,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@
 
  - Fix set break point in an ipc message in renderer will lead to devtools crash
  - Add `Editor.Protocol.register` in renderer process
+ - Add `deprecate` function in global and window
+ - deprecate `pkgDependencies` in `package.json`, use `packages` instead
+ - deprecate `panels` in `package.json`, use `panel` instead. for multiple panel registry, use `panel.x` for the additional panel.
+ - deprecate `Editor.registerPanel`, use `Editor.polymerPanel` instead
+ - deprecate `Editor.registerElement`, use `Editor.polymerElement` instead
 
 ### v0.5.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,10 @@
 ### v0.5.2 (developing)
 
  - Fix set break point in an ipc message in renderer will lead to devtools crash
+ - Fix console error stack will add main-process call stack when we raise a renderer process error
  - Add `Editor.Protocol.register` in renderer process
  - Add `deprecate` function in global and window
+ - Add `Editor.trace` for trace log in main and renderer process
  - deprecate `pkgDependencies` in `package.json`, use `packages` instead
  - deprecate `panels` in `package.json`, use `panel` instead. for multiple panel registry, use `panel.x` for the additional panel.
  - deprecate `Editor.registerPanel`, use `Editor.polymerPanel` instead

--- a/lib/main/console.js
+++ b/lib/main/console.js
@@ -21,6 +21,31 @@ let _logs = [];
 // ==========================
 
 /**
+ * Trace the log
+ * @method trace
+ * @param {string} method - log method
+ * @param {...*} [args] - whatever arguments the message needs
+ */
+Console.trace = function (level,...args) {
+  let text = Util.format.apply(Util, args);
+
+  let err = new Error('dummy');
+  let lines = err.stack.split('\n');
+
+  // remove stack frame of Editor.error without allocating new Array
+  lines.shift();
+  lines[0] = text;
+  text = lines.join('\n');
+
+  if ( _consoleConnected ) {
+    _logs.push({ type: level, message: text });
+  }
+
+  Winston[level](text);
+  Ipc.sendToWins(`editor:console-${level}`,text);
+};
+
+/**
  * Log the normal message and show on the console.
  * The method will send ipc message `editor:console-log` to all windows.
  * @method log
@@ -29,8 +54,9 @@ let _logs = [];
 Console.log = function (...args) {
   let text = Util.format.apply(Util, args);
 
-  if ( _consoleConnected )
+  if ( _consoleConnected ) {
     _logs.push({ type: 'log', message: text });
+  }
 
   Winston.normal(text);
   Ipc.sendToWins('editor:console-log',text);
@@ -45,8 +71,9 @@ Console.log = function (...args) {
 Console.success = function (...args) {
   let text = Util.format.apply(Util, args);
 
-  if ( _consoleConnected )
+  if ( _consoleConnected ) {
     _logs.push({ type: 'success', message: text });
+  }
 
   Winston.success(text);
   Ipc.sendToWins('editor:console-success',text);
@@ -61,8 +88,9 @@ Console.success = function (...args) {
 Console.failed = function (...args) {
   let text = Util.format.apply(Util, args);
 
-  if ( _consoleConnected )
+  if ( _consoleConnected ) {
     _logs.push({ type: 'failed', message: text });
+  }
 
   Winston.failed(text);
   Ipc.sendToWins('editor:console-failed',text);
@@ -77,8 +105,9 @@ Console.failed = function (...args) {
 Console.info = function (...args) {
   let text = Util.format.apply(Util, args);
 
-  if ( _consoleConnected )
+  if ( _consoleConnected ) {
     _logs.push({ type: 'info', message: text });
+  }
 
   Winston.info(text);
   Ipc.sendToWins('editor:console-info',text);
@@ -94,8 +123,9 @@ Console.info = function (...args) {
 Console.warn = function (...args) {
   let text = Util.format.apply(Util, args);
 
-  if ( _consoleConnected )
+  if ( _consoleConnected ) {
     _logs.push({ type: 'warn', message: text });
+  }
 
   Winston.warn(text);
   Ipc.sendToWins('editor:console-warn',text);
@@ -176,28 +206,43 @@ Console.clearLog = function () {
 
 const ipcMain = Electron.ipcMain;
 
+function _logInMain (level, text, ...args) {
+  text = Util.format.apply(Util, [text,args]);
+
+  if ( _consoleConnected ) {
+    _logs.push({ type: level, message: text });
+  }
+
+  Winston[level](text);
+  Ipc.sendToWins(`editor:console-${level}`,text);
+}
+
 ipcMain.on('editor:renderer-console-log', (event, ...args) => {
-  Console.log.apply(null,args);
+  _logInMain.apply(null, ['log',...args]);
 });
 
 ipcMain.on('editor:renderer-console-success', (event, ...args) => {
-  Console.success.apply(null,args);
+  _logInMain.apply(null, ['success',...args]);
 });
 
 ipcMain.on('editor:renderer-console-failed', (event, ...args) => {
-  Console.failed.apply(null,args);
+  _logInMain.apply(null, ['failed',...args]);
 });
 
 ipcMain.on('editor:renderer-console-info', (event, ...args) => {
-  Console.info.apply(null,args);
+  _logInMain.apply(null, ['info',...args]);
 });
 
 ipcMain.on('editor:renderer-console-warn', (event, ...args) => {
-  Console.warn.apply(null,args);
+  _logInMain.apply(null, ['warn',...args]);
 });
 
 ipcMain.on('editor:renderer-console-error', (event, ...args) => {
-  Console.error.apply(null,args);
+  _logInMain.apply(null, ['error',...args]);
+});
+
+ipcMain.on('editor:renderer-console-trace', (event, level, ...args) => {
+  _logInMain.apply(null, [level,...args]);
 });
 
 ipcMain.on('editor:console-query', ( event ) => {

--- a/lib/main/deprecated.js
+++ b/lib/main/deprecated.js
@@ -1,0 +1,1 @@
+'use strict';

--- a/lib/main/index.js
+++ b/lib/main/index.js
@@ -34,8 +34,23 @@ EditorM.i18n = require('./i18n');
 EditorM.T = EditorM.i18n.t;
 
 // global
-global.Editor = EditorM;
 global.unused = () => {};
+global.deprecate = function (fn, msg) {
+  let warned = false;
+  function deprecated() {
+    if (!warned) {
+      EditorM.warn(msg);
+      warned = true;
+    }
+    return fn.apply(this, arguments);
+  }
+
+  return deprecated;
+};
+global.Editor = EditorM;
+
+//
+require('./deprecated');
 
 // export
 module.exports = EditorM;

--- a/lib/main/index.js
+++ b/lib/main/index.js
@@ -35,12 +35,18 @@ EditorM.T = EditorM.i18n.t;
 
 // global
 global.unused = () => {};
-global.deprecate = function (fn, msg) {
+global.deprecate = function (fn, msg, trace) {
+  trace = trace !== undefined ? trace : false;
   let warned = false;
+
   function deprecated() {
-    if (!warned) {
-      EditorM.warn(msg);
-      warned = true;
+    if ( trace ) {
+      EditorM.warnTrace(msg);
+    } else {
+      if ( !warned ) {
+        EditorM.warn(msg);
+        warned = true;
+      }
     }
     return fn.apply(this, arguments);
   }

--- a/lib/main/index.js
+++ b/lib/main/index.js
@@ -41,7 +41,7 @@ global.deprecate = function (fn, msg, trace) {
 
   function deprecated() {
     if ( trace ) {
-      EditorM.warnTrace(msg);
+      EditorM.trace('warn',msg);
     } else {
       if ( !warned ) {
         EditorM.warn(msg);

--- a/lib/main/ipc.js
+++ b/lib/main/ipc.js
@@ -157,7 +157,7 @@ Ipc.sendToMain = function (message, ...args) {
  * @param {number} [timeout] - timeout of the callback
  * @example
  * ```js
- * Ipc.sendToPanel( 'package.panel', 'foo-bar', 'foo', 'bar' );
+ * Ipc.sendToPanel( 'panel-id', 'foo-bar', 'foo', 'bar' );
  * ```
  */
 Ipc.sendToPanel = function (panelID, message, ...args) {

--- a/lib/main/main-menu.js
+++ b/lib/main/main-menu.js
@@ -401,7 +401,7 @@ function _builtinMainMenu () {
             {
               label: 'send2panel \'foo:bar\' foobar.panel',
               click () {
-                Ipc.sendToPanel( 'foobar.panel', 'foo:bar' );
+                Ipc.sendToPanel( 'foobar', 'foo:bar' );
               }
             },
           ],

--- a/lib/main/package.js
+++ b/lib/main/package.js
@@ -197,12 +197,11 @@ Package.load = function ( path, opts, cb ) {
       let panels = pjsonObj;
       let backwards = false;
       if ( pjsonObj.panels ) {
-        Console.warn(
-          `Package ${pjsonObj.name} parse warning: "panels" is deprecated, use "panel" instead.
+        Console.warn(`
+           Package ${pjsonObj.name} parse warning: "panels" is deprecated, use "panel" instead.
            For multiple panel, use "panel.x", "panel.y" as your register field.
            NOTE: Don't forget to change your "Editor.Ipc.sendToPanel" message, since your panelID has changed.
-          `
-        );
+        `);
         panels = pjsonObj.panels;
         backwards = true;
       }
@@ -226,7 +225,7 @@ Package.load = function ( path, opts, cb ) {
         }
 
         // setup default properties
-        let panelInfo = pjsonObj[name];
+        let panelInfo = panels[name];
         _.defaults(panelInfo, {
           type: 'dockable',
           title: panelID,

--- a/lib/main/package.js
+++ b/lib/main/package.js
@@ -195,6 +195,7 @@ Package.load = function ( path, opts, cb ) {
       // register panels
       // TEMP: backwards compat
       let panels = pjsonObj;
+      let backwards = false;
       if ( pjsonObj.panels ) {
         Console.warn(
           `Package ${pjsonObj.name} parse warning: "panels" is deprecated, use "panel" instead.
@@ -203,15 +204,21 @@ Package.load = function ( path, opts, cb ) {
           `
         );
         panels = pjsonObj.panels;
+        backwards = true;
       }
 
       for ( let name in panels ) {
-        // if the name is not start with panel, skip it
-        if ( name.indexOf('panel') !== 0 ) {
-          continue;
-        }
+        let panelID;
 
-        let panelID = name.replace(/^panel/, pjsonObj.name);
+        if ( backwards ) {
+          panelID = `${pjsonObj.name}.${name}`;
+        } else {
+          // if the name is not start with panel, skip it
+          if ( name.indexOf('panel') !== 0 ) {
+            continue;
+          }
+          panelID = name.replace(/^panel/, pjsonObj.name);
+        }
 
         if ( _panel2info[panelID] ) {
           Console.failed( `Failed to load panel "${name}" from "${pjsonObj.name}", the panelID ${panelID} already exists` );

--- a/lib/main/package.js
+++ b/lib/main/package.js
@@ -93,7 +93,7 @@ Package.load = function ( path, opts, cb ) {
 
       // TEMP: backwards compat
       if ( pjsonObj.pkgDependencies ) {
-        Console.warn(`Package ${name} parse warning: "pkgDependencies" is deprecated, use "packages" instead.`);
+        Console.warn(`Package ${pjsonObj.name} parse warning: "pkgDependencies" is deprecated, use "packages" instead.`);
         pkgdeps = pjsonObj.pkgDependencies;
       }
 
@@ -197,9 +197,9 @@ Package.load = function ( path, opts, cb ) {
       let panels = pjsonObj;
       if ( pjsonObj.panels ) {
         Console.warn(
-          `Package ${name} parse warning: panels is deprecated, use panel instead.
-           For multiple panel, use panel.x, panel.y as your register field.
-           NOTE: Don't forget to change your sendToPanel message, since your panelID has changed.
+          `Package ${pjsonObj.name} parse warning: "panels" is deprecated, use "panel" instead.
+           For multiple panel, use "panel.x", "panel.y" as your register field.
+           NOTE: Don't forget to change your "Editor.Ipc.sendToPanel" message, since your panelID has changed.
           `
         );
         panels = pjsonObj.panels;

--- a/lib/main/package.js
+++ b/lib/main/package.js
@@ -56,10 +56,10 @@ Package.load = function ( path, opts, cb ) {
     return;
   }
 
-  let packageJsonPath = Path.join( path, 'package.json' );
-  let packageObj;
+  let pjsonPath = Path.join( path, 'package.json' );
+  let pjsonObj;
   try {
-    packageObj = JSON.parse(Fs.readFileSync(packageJsonPath));
+    pjsonObj = JSON.parse(Fs.readFileSync(pjsonPath));
   } catch (err) {
     if ( cb ) {
       cb ( new Error( `Failed to load 'package.json': ${err.message}` ) );
@@ -68,7 +68,7 @@ Package.load = function ( path, opts, cb ) {
   }
 
   // check host, if we don't have the host, skip load it
-  for ( let host in packageObj.hosts ) {
+  for ( let host in pjsonObj.hosts ) {
     let currentVer = _versions[host];
     if ( !currentVer ) {
       if ( cb ) {
@@ -77,7 +77,7 @@ Package.load = function ( path, opts, cb ) {
       return;
     }
 
-    let requireVer = packageObj.hosts[host];
+    let requireVer = pjsonObj.hosts[host];
     if ( !Semver.satisfies( currentVer, requireVer ) ) {
       if ( cb ) {
         cb ( new Error( `Host '${host}' require ver ${requireVer}` ) );
@@ -89,12 +89,20 @@ Package.load = function ( path, opts, cb ) {
   //
   Async.series([
     next => {
-      if ( !packageObj.pkgDependencies ) {
+      let pkgdeps = pjsonObj.packages;
+
+      // TEMP: backwards compat
+      if ( pjsonObj.pkgDependencies ) {
+        Console.warn(`Package ${name} parse warning: "pkgDependencies" is deprecated, use "packages" instead.`);
+        pkgdeps = pjsonObj.pkgDependencies;
+      }
+
+      if ( !pkgdeps ) {
         next ();
         return;
       }
 
-      Async.eachSeries(Object.keys(packageObj.pkgDependencies), (pkgName, done) => {
+      Async.eachSeries(Object.keys(pkgdeps), (pkgName, done) => {
         let pkgPath = Package.find( pkgName );
         if ( !pkgPath ) {
           return done ( new Error(`Can not find dependencied package ${pkgName}`) );
@@ -105,25 +113,25 @@ Package.load = function ( path, opts, cb ) {
     },
 
     next => {
-      packageObj._path = path;
-      _build ( packageObj, opts.build, ( err, destPath ) => {
+      pjsonObj._path = path;
+      _build ( pjsonObj, opts.build, ( err, destPath ) => {
         if ( err ) {
           next ( new Error( `Building failed: ${err.message}` ) );
           return;
         }
 
-        packageObj._destPath = destPath;
+        pjsonObj._destPath = destPath;
         next ();
       });
     },
 
     next => {
       // register i18n from i18n/${lang}.js
-      let i18nFile = Path.join( packageObj._destPath, 'i18n', `${_lang}.js` );
+      let i18nFile = Path.join( pjsonObj._destPath, 'i18n', `${_lang}.js` );
       if ( Fs.existsSync(i18nFile) ) {
         try {
           i18n.extend({
-            [packageObj.name]: require(i18nFile),
+            [pjsonObj.name]: require(i18nFile),
           });
         } catch (e) {
           next ( new Error( `Failed to load ${i18nFile}: ${e.stack}` ) );
@@ -135,12 +143,12 @@ Package.load = function ( path, opts, cb ) {
 
       // load main.js
       // NOTE: it is possible for a package that does not have main-process code
-      if ( packageObj.main ) {
-        let mainPath = Path.join( packageObj._destPath, packageObj.main );
+      if ( pjsonObj.main ) {
+        let mainPath = Path.join( pjsonObj._destPath, pjsonObj.main );
         try {
           main = require(mainPath);
         } catch (e) {
-          next ( new Error( `Failed to load ${packageObj.main}: ${e.stack}` ) );
+          next ( new Error( `Failed to load ${pjsonObj.main}: ${e.stack}` ) );
           return;
         }
       }
@@ -151,14 +159,14 @@ Package.load = function ( path, opts, cb ) {
         for ( let prop in main.messages ) {
           let fn = main.messages[prop];
           if ( typeof fn === 'function' ) {
-            ipcListener.on( _messageName(packageObj.name,prop), fn.bind(main) );
+            ipcListener.on( _messageName(pjsonObj.name,prop), fn.bind(main) );
           }
         }
-        packageObj._ipc = ipcListener;
+        pjsonObj._ipc = ipcListener;
       }
 
       // register main-menu
-      let mainMenuInfo = packageObj['main-menu'];
+      let mainMenuInfo = pjsonObj['main-menu'];
       if ( mainMenuInfo && typeof mainMenuInfo === 'object' ) {
         for ( let menuPath in mainMenuInfo ) {
           let fmtMenuPath = i18n.formatPath(menuPath);
@@ -176,7 +184,7 @@ Package.load = function ( path, opts, cb ) {
 
           // create NativeImage for icon
           if ( menuOpts.icon ) {
-            let icon = NativeImage.createFromPath( Path.join(packageObj._destPath, menuOpts.icon) );
+            let icon = NativeImage.createFromPath( Path.join(pjsonObj._destPath, menuOpts.icon) );
             template.icon = icon;
           }
 
@@ -184,33 +192,49 @@ Package.load = function ( path, opts, cb ) {
         }
       }
 
-      // register panel
-      if ( packageObj.panels && typeof packageObj.panels === 'object' ) {
-        for ( let panelName in packageObj.panels ) {
-          let panelID = packageObj.name + '.' + panelName;
-          if ( _panel2info[panelID] ) {
-            Console.failed( `Failed to load panel "${panelName}" from "${packageObj.name}", already exists` );
-            continue;
-          }
+      // register panels
+      // TEMP: backwards compat
+      let panels = pjsonObj;
+      if ( pjsonObj.panels ) {
+        Console.warn(
+          `Package ${name} parse warning: panels is deprecated, use panel instead.
+           For multiple panel, use panel.x, panel.y as your register field.
+           NOTE: Don't forget to change your sendToPanel message, since your panelID has changed.
+          `
+        );
+        panels = pjsonObj.panels;
+      }
 
-          // setup default properties
-          let panelInfo = packageObj.panels[panelName];
-          _.defaults(panelInfo, {
-            type: 'dockable',
-            title: panelID,
-            popable: true,
-            messages: [],
-            path: packageObj._destPath,
-          });
-
-          //
-          _panel2info[panelID] = panelInfo;
+      for ( let name in panels ) {
+        // if the name is not start with panel, skip it
+        if ( name.indexOf('panel') !== 0 ) {
+          continue;
         }
+
+        let panelID = name.replace(/^panel/, pjsonObj.name);
+
+        if ( _panel2info[panelID] ) {
+          Console.failed( `Failed to load panel "${name}" from "${pjsonObj.name}", the panelID ${panelID} already exists` );
+          continue;
+        }
+
+        // setup default properties
+        let panelInfo = pjsonObj[name];
+        _.defaults(panelInfo, {
+          type: 'dockable',
+          title: panelID,
+          popable: true,
+          messages: [],
+          path: pjsonObj._destPath,
+        });
+
+        //
+        _panel2info[panelID] = panelInfo;
       }
 
       //
-      _path2package[path] = packageObj;
-      _name2packagePath[packageObj.name] = path;
+      _path2package[path] = pjsonObj;
+      _name2packagePath[pjsonObj.name] = path;
 
       // invoke main.load
       if ( main && main.load ) {
@@ -225,8 +249,8 @@ Package.load = function ( path, opts, cb ) {
       }
 
       //
-      Console.success( `${packageObj.name} loaded` );
-      Ipc.sendToWins('editor:package-loaded', packageObj.name);
+      Console.success( `${pjsonObj.name} loaded` );
+      Ipc.sendToWins('editor:package-loaded', pjsonObj.name);
       next ();
     },
 
@@ -240,8 +264,8 @@ Package.load = function ( path, opts, cb ) {
  * @param {function} cb - Callback when finish unloading
  */
 Package.unload = function ( path, cb ) {
-  let packageObj = _path2package[path];
-  if ( !packageObj ) {
+  let pjsonObj = _path2package[path];
+  if ( !pjsonObj ) {
     if ( cb ) {
       cb ();
     }
@@ -249,18 +273,18 @@ Package.unload = function ( path, cb ) {
   }
 
   // unregister i18n table
-  i18n.unset([packageObj.name]);
+  i18n.unset([pjsonObj.name]);
 
   // unregister panel
-  if ( packageObj.panels && typeof packageObj.panels === 'object' ) {
-    for ( let panelName in packageObj.panels ) {
-      let panelID = packageObj.name + '.' + panelName;
+  if ( pjsonObj.panels && typeof pjsonObj.panels === 'object' ) {
+    for ( let panelName in pjsonObj.panels ) {
+      let panelID = pjsonObj.name + '.' + panelName;
       delete _panel2info[panelID];
     }
   }
 
   // unregister main menu
-  let mainMenuInfo = packageObj['main-menu'];
+  let mainMenuInfo = pjsonObj['main-menu'];
   if ( mainMenuInfo && typeof mainMenuInfo === 'object' ) {
     for ( let menuPath in mainMenuInfo ) {
       let fmtMenuPath = i18n.formatPath(menuPath);
@@ -269,14 +293,14 @@ Package.unload = function ( path, cb ) {
   }
 
   // unregister main ipc messages
-  if ( packageObj._ipc ) {
-    packageObj._ipc.clear();
+  if ( pjsonObj._ipc ) {
+    pjsonObj._ipc.clear();
   }
 
   // uncache main.js
-  if ( packageObj.main ) {
+  if ( pjsonObj.main ) {
     let cache = require.cache;
-    let mainPath = Path.join( packageObj._destPath, packageObj.main );
+    let mainPath = Path.join( pjsonObj._destPath, pjsonObj.main );
     let cachedModule = cache[mainPath];
 
     // invoke main.unload()
@@ -286,22 +310,22 @@ Package.unload = function ( path, cb ) {
         try {
           main.unload();
         } catch (err) {
-          Console.failed( `Failed to unload "${packageObj.main}" from "${packageObj.name}": ${err.stack}.` );
+          Console.failed( `Failed to unload "${pjsonObj.main}" from "${pjsonObj.name}": ${err.stack}.` );
         }
       }
 
-      _clearDependence( packageObj._destPath, cachedModule.children );
+      _clearDependence( pjsonObj._destPath, cachedModule.children );
       delete cache[mainPath];
     } else {
-      Console.failed( `Failed to uncache module ${packageObj.main}: Can not find it.` );
+      Console.failed( `Failed to uncache module ${pjsonObj.main}: Can not find it.` );
     }
   }
 
   //
   delete _path2package[path];
-  delete _name2packagePath[packageObj.name];
-  Console.success( `${packageObj.name} unloaded` );
-  Ipc.sendToWins('editor:package-unloaded', packageObj.name);
+  delete _name2packagePath[pjsonObj.name];
+  Console.success( `${pjsonObj.name} unloaded` );
+  Ipc.sendToWins('editor:package-unloaded', pjsonObj.name);
 
   if ( cb ) {
     cb ();
@@ -322,14 +346,14 @@ Package.reload = function ( path, opts, cb ) {
 
   Async.series([
     next => {
-      let packageObj = _path2package[path];
-      if ( !packageObj ) {
+      let pjsonObj = _path2package[path];
+      if ( !pjsonObj ) {
         next ();
         return;
       }
 
-      if ( rebuild && packageObj.build ) {
-        Console.log( 'Rebuilding ' + packageObj.name );
+      if ( rebuild && pjsonObj.build ) {
+        Console.log( 'Rebuilding ' + pjsonObj.name );
         Package.build( path, next );
         return;
       }
@@ -514,10 +538,10 @@ function _messageName ( packageName, messageName ) {
   return messageName;
 }
 
-function _build ( packageObj, force, cb ) {
-  if ( !packageObj.build ) {
+function _build ( pjsonObj, force, cb ) {
+  if ( !pjsonObj.build ) {
     if ( cb ) {
-      cb ( null, packageObj._path );
+      cb ( null, pjsonObj._path );
     }
 
     return;
@@ -525,15 +549,15 @@ function _build ( packageObj, force, cb ) {
 
   if ( !force ) {
     // check if bin/dev exists
-    let binPath = Path.join( packageObj._path, 'bin/dev' );
+    let binPath = Path.join( pjsonObj._path, 'bin/dev' );
     if ( Fs.existsSync(binPath) ) {
-      let packageJsonPath = Path.join( binPath, 'package.json');
+      let pjsonPath = Path.join( binPath, 'package.json');
 
-      if (  Fs.existsSync(packageJsonPath)  ) {
+      if (  Fs.existsSync(pjsonPath)  ) {
         // check if bin/dev/package.json have the same version
-        let binPackageObj = JSON.parse(Fs.readFileSync(packageJsonPath));
+        let binPackageObj = JSON.parse(Fs.readFileSync(pjsonPath));
 
-        if ( packageObj.version === binPackageObj.version ) {
+        if ( pjsonObj.version === binPackageObj.version ) {
           if ( cb ) {
             cb ( null, binPath );
           }
@@ -544,8 +568,8 @@ function _build ( packageObj, force, cb ) {
     }
   }
 
-  Console.log( 'Building ' + packageObj.name );
-  Package.build( packageObj._path, cb );
+  Console.log( 'Building ' + pjsonObj.name );
+  Package.build( pjsonObj._path, cb );
 }
 
 function _clearDependence(path, deps) {

--- a/lib/main/package.js
+++ b/lib/main/package.js
@@ -282,11 +282,27 @@ Package.unload = function ( path, cb ) {
   i18n.unset([pjsonObj.name]);
 
   // unregister panel
-  if ( pjsonObj.panels && typeof pjsonObj.panels === 'object' ) {
-    for ( let panelName in pjsonObj.panels ) {
-      let panelID = pjsonObj.name + '.' + panelName;
-      delete _panel2info[panelID];
+  // TEMP: backwards compat
+  let panels = pjsonObj;
+  let backwards = false;
+  if ( pjsonObj.panels ) {
+    panels = pjsonObj.panels;
+    backwards = true;
+  }
+  for ( let name in panels ) {
+    let panelID;
+
+    if ( backwards ) {
+      panelID = `${pjsonObj.name}.${name}`;
+    } else {
+      // if the name is not start with panel, skip it
+      if ( name.indexOf('panel') !== 0 ) {
+        continue;
+      }
+      panelID = name.replace(/^panel/, pjsonObj.name);
     }
+
+    delete _panel2info[panelID];
   }
 
   // unregister main menu

--- a/lib/renderer/console.js
+++ b/lib/renderer/console.js
@@ -15,6 +15,31 @@ const Ipc = require('./ipc');
 // ==========================
 
 /**
+ * Trace the log
+ * @method trace
+ * @param {string} method - log method
+ * @param {...*} [args] - whatever arguments the message needs
+ */
+Console.trace = function (level, text, ...args) {
+  if ( args.length ) {
+    text = Util.format.apply(Util, [text,...args]);
+  } else {
+    text = '' + text;
+  }
+  console.trace(text);
+
+  let e = new Error('dummy');
+  let lines = e.stack.split('\n');
+
+  // remove stack frame of Editor.error without allocating new Array
+  lines.shift();
+  lines[0] = text;
+  text = lines.join('\n');
+
+  Ipc.sendToMain('editor:renderer-console-trace',level,text);
+};
+
+/**
  * Log the normal message and show on the console.
  * The method will send ipc message `editor:renderer-console-log` to core.
  * @method log

--- a/lib/renderer/deprecated.js
+++ b/lib/renderer/deprecated.js
@@ -1,4 +1,12 @@
 'use strict';
 
-Editor.registerPanel = deprecate(Editor.polymerPanel, 'Editor.registerPanel is deprecated, use Editor.polymerPanel instead');
-Editor.registerElement = deprecate(Editor.polymerElement, 'Editor.registerElement is deprecated, use Editor.polymerElement instead');
+Editor.registerPanel = deprecate(
+  Editor.polymerPanel,
+  'Editor.registerPanel is deprecated, use Editor.polymerPanel instead',
+  true
+);
+Editor.registerElement = deprecate(
+  Editor.polymerElement,
+  'Editor.registerElement is deprecated, use Editor.polymerElement instead',
+  true
+);

--- a/lib/renderer/deprecated.js
+++ b/lib/renderer/deprecated.js
@@ -1,0 +1,4 @@
+'use strict';
+
+Editor.registerPanel = deprecate(Editor.polymerPanel, 'Editor.registerPanel is deprecated, use Editor.polymerPanel instead');
+Editor.registerElement = deprecate(Editor.polymerElement, 'Editor.registerElement is deprecated, use Editor.polymerElement instead');

--- a/lib/renderer/editor.js
+++ b/lib/renderer/editor.js
@@ -10,6 +10,7 @@ module.exports = EditorR;
 const Electron = require('electron');
 
 const Protocol = require('./protocol');
+const Console = require('./console');
 
 /**
  * Require module through url path
@@ -34,64 +35,6 @@ EditorR.loadProfile = function ( name, type, cb ) {
       cb (profile);
     }
   });
-};
-
-// ==========================
-// extends
-// ==========================
-
-EditorR.registerElement = function ( obj ) {
-  if ( !obj.is ) {
-    let script = document.currentScript;
-    let parent = script.parentElement;
-    if ( parent && parent.tagName === 'DOM-MODULE' ) {
-      obj.is = parent.id;
-    } else {
-      EditorR.error('Failed to register widget %s, the script must inside a <dom-module>.');
-      return;
-    }
-  }
-
-  if ( !EditorR.elements ) {
-    EditorR.elements = {};
-  }
-
-  if ( EditorR.elements[obj.is] ) {
-    EditorR.error('Failed to register widget %s, already exists.', obj.is );
-    return;
-  }
-
-  obj._T = function ( key, option ) {
-    return EditorR.T( key, option );
-  };
-  EditorR.elements[obj.is] = Polymer(obj);
-};
-
-EditorR.registerPanel = function ( panelID, obj ) {
-  if ( !obj.is ) {
-    let script = document.currentScript;
-    let parent = script.parentElement;
-    if ( parent && parent.tagName === 'DOM-MODULE' ) {
-      obj.is = parent.id;
-    } else {
-      EditorR.error('Failed to register panel %s, the script must inside a <dom-module>.', panelID);
-      return;
-    }
-  }
-
-  if ( !EditorR.panels ) {
-    EditorR.panels = {};
-  }
-
-  if ( EditorR.panels[panelID] !== undefined ) {
-    EditorR.error('Failed to register panel %s, panelID has been registered.', panelID);
-    return;
-  }
-
-  obj._T = function ( key, option ) {
-    return EditorR.T( key, option );
-  };
-  EditorR.panels[panelID] = Polymer(obj);
 };
 
 // ==========================

--- a/lib/renderer/index.js
+++ b/lib/renderer/index.js
@@ -33,9 +33,29 @@ EditorR.T = EditorR.i18n.t;
 //
 EditorR.UI = require('./ui');
 
+// NOTE: deprecated
+EditorR.polymerPanel = EditorR.UI.PolymerUtils.registerPanel;
+EditorR.polymerElement = EditorR.UI.PolymerUtils.registerElement;
+
 // global
 window.unused = () => {};
+window.deprecate = function (fn, msg) {
+  let warned = false;
+  function deprecated() {
+    if (!warned) {
+      EditorR.warn(msg);
+      warned = true;
+    }
+    return fn.apply(this, arguments);
+  }
+
+  return deprecated;
+};
+
 window.Editor = EditorR;
+
+//
+require('./deprecated');
 
 // export
 module.exports = EditorR;

--- a/lib/renderer/index.js
+++ b/lib/renderer/index.js
@@ -39,12 +39,18 @@ EditorR.polymerElement = EditorR.UI.PolymerUtils.registerElement;
 
 // global
 window.unused = () => {};
-window.deprecate = function (fn, msg) {
+window.deprecate = function (fn, msg, trace) {
+  trace = trace !== undefined ? trace : false;
   let warned = false;
+
   function deprecated() {
-    if (!warned) {
-      EditorR.warn(msg);
-      warned = true;
+    if ( trace ) {
+      EditorR.trace('warn',msg);
+    } else {
+      if (!warned) {
+        EditorR.warn(msg);
+        warned = true;
+      }
     }
     return fn.apply(this, arguments);
   }

--- a/lib/renderer/panel.js
+++ b/lib/renderer/panel.js
@@ -10,7 +10,6 @@ module.exports = Panel;
 const Electron = require('electron');
 const Mousetrap = require('mousetrap');
 
-const EditorR = require('./editor');
 const UI = require('./ui');
 const Console = require('./console');
 const Ipc = require('./ipc');
@@ -53,7 +52,7 @@ Panel.load = function ( panelID, cb ) {
         return;
       }
 
-      let frameCtor = EditorR.panels[panelID];
+      let frameCtor = UI.PolymerUtils.panels[panelID];
       if ( !frameCtor ) {
         Console.error(`Can not find constructor for panelID ${panelID}`);
         if ( cb ) {

--- a/lib/renderer/ui/utils/polymer-utils.js
+++ b/lib/renderer/ui/utils/polymer-utils.js
@@ -5,6 +5,8 @@ module.exports = PolymerUtils;
 
 // requires
 const DomUtils = require('./dom-utils');
+const Console = require('../../console');
+const i18n = require('../../i18n');
 
 let _importCount = 0;
 
@@ -113,4 +115,58 @@ PolymerUtils.import = function ( url, cb ) {
       cb ( new Error(`${url} not found.`) );
     }
   });
+};
+
+PolymerUtils.registerElement = function ( obj ) {
+  if ( !obj.is ) {
+    let script = document.currentScript;
+    let parent = script.parentElement;
+    if ( parent && parent.tagName === 'DOM-MODULE' ) {
+      obj.is = parent.id;
+    } else {
+      Console.error('Failed to register widget %s, the script must inside a <dom-module>.');
+      return;
+    }
+  }
+
+  if ( !PolymerUtils.elements ) {
+    PolymerUtils.elements = {};
+  }
+
+  if ( PolymerUtils.elements[obj.is] ) {
+    Console.error('Failed to register widget %s, already exists.', obj.is );
+    return;
+  }
+
+  obj._T = function ( key, option ) {
+    return i18n.t( key, option );
+  };
+  PolymerUtils.elements[obj.is] = Polymer(obj);
+};
+
+PolymerUtils.registerPanel = function ( panelID, obj ) {
+  if ( !obj.is ) {
+    let script = document.currentScript;
+    let parent = script.parentElement;
+    if ( parent && parent.tagName === 'DOM-MODULE' ) {
+      obj.is = parent.id;
+    } else {
+      Console.error(`Failed to register panel ${panelID}, the script must inside a <dom-module>.`);
+      return;
+    }
+  }
+
+  if ( !PolymerUtils.panels ) {
+    PolymerUtils.panels = {};
+  }
+
+  if ( PolymerUtils.panels[panelID] !== undefined ) {
+    Console.error(`Failed to register panel ${panelID}, panelID has been registered.`);
+    return;
+  }
+
+  obj._T = function ( key, option ) {
+    return i18n.t( key, option );
+  };
+  PolymerUtils.panels[panelID] = Polymer(obj);
 };

--- a/static/layout.json
+++ b/static/layout.json
@@ -5,8 +5,8 @@
         {
           "active": 0,
           "panels": [
-            "tester.panel",
-            "ipc-debugger.panel"
+            "tester",
+            "ipc-debugger"
           ],
           "type": "panel",
           "width": 350
@@ -14,7 +14,7 @@
         {
           "active": 0,
           "panels": [
-            "package-manager.panel"
+            "package-manager"
           ],
           "type": "panel"
         }
@@ -25,7 +25,7 @@
     {
       "active": 0,
       "panels": [
-        "console.panel"
+        "console"
       ],
       "type": "panel",
       "height": 300

--- a/test/fixtures/packages/dep-01/package.json
+++ b/test/fixtures/packages/dep-01/package.json
@@ -4,7 +4,7 @@
   "description": "A Simple Package Test Fixture",
   "author": "Firebox Technology",
   "main": "main.js",
-  "pkgDependencies": {
+  "packages": {
     "dep-02": "0.0.1"
   }
 }

--- a/test/fixtures/packages/host-not-exists/package.json
+++ b/test/fixtures/packages/host-not-exists/package.json
@@ -12,15 +12,13 @@
       "message": "demo-simple:open"
     }
   },
-  "panels": {
-    "panel": {
-      "frame": "panel/panel.html",
-      "type": "dockable",
-      "title": "Simple",
-      "width": 800,
-      "height": 600,
-      "messages": [
-      ]
-    }
+  "panel": {
+    "frame": "panel/panel.html",
+    "type": "dockable",
+    "title": "Simple",
+    "width": 800,
+    "height": 600,
+    "messages": [
+    ]
   }
 }

--- a/test/fixtures/packages/localize/package.json
+++ b/test/fixtures/packages/localize/package.json
@@ -9,15 +9,13 @@
       "message": "localize:open"
     }
   },
-  "panels": {
-    "panel": {
-      "frame": "panel/panel.html",
-      "type": "dockable",
-      "title": "Localize",
-      "width": 800,
-      "height": 600,
-      "messages": [
-      ]
-    }
+  "panel": {
+    "frame": "panel/panel.html",
+    "type": "dockable",
+    "title": "Localize",
+    "width": 800,
+    "height": 600,
+    "messages": [
+    ]
   }
 }

--- a/test/fixtures/packages/localize/panel/panel.html
+++ b/test/fixtures/packages/localize/panel/panel.html
@@ -13,7 +13,7 @@
   </template>
 
   <script>
-    Editor.registerPanel( 'localize.panel', {
+    Editor.polymerPanel( 'localize', {
     });
   </script>
 </dom-module>

--- a/test/fixtures/packages/main-deps/package.json
+++ b/test/fixtures/packages/main-deps/package.json
@@ -9,15 +9,13 @@
       "message": "demo-simple:open"
     }
   },
-  "panels": {
-    "panel": {
-      "frame": "panel/panel.html",
-      "type": "dockable",
-      "title": "Simple",
-      "width": 800,
-      "height": 600,
-      "messages": [
-      ]
-    }
+  "panel": {
+    "frame": "panel/panel.html",
+    "type": "dockable",
+    "title": "Simple",
+    "width": 800,
+    "height": 600,
+    "messages": [
+    ]
   }
 }

--- a/test/fixtures/packages/main-deps/panel/panel.html
+++ b/test/fixtures/packages/main-deps/panel/panel.html
@@ -13,7 +13,7 @@
   </template>
 
   <script>
-    Editor.registerPanel( 'demo-simple.panel', {
+    Editor.polymerPanel( 'demo-simple', {
     });
   </script>
 </dom-module>

--- a/test/fixtures/packages/main-js-broken/package.json
+++ b/test/fixtures/packages/main-js-broken/package.json
@@ -9,15 +9,13 @@
       "message": "demo-simple:open"
     }
   },
-  "panels": {
-    "panel": {
-      "frame": "panel/panel.html",
-      "type": "dockable",
-      "title": "Simple",
-      "width": 800,
-      "height": 600,
-      "messages": [
-      ]
-    }
+  "panel": {
+    "frame": "panel/panel.html",
+    "type": "dockable",
+    "title": "Simple",
+    "width": 800,
+    "height": 600,
+    "messages": [
+    ]
   }
 }

--- a/test/fixtures/packages/needs-build/package.json
+++ b/test/fixtures/packages/needs-build/package.json
@@ -13,14 +13,12 @@
   "widgets": {
     "simple-widget": "widget/simple.html"
   },
-  "panels": {
-    "panel": {
-      "frame": "panel/panel.html",
-      "type": "dockable",
-      "title": "Simple",
-      "width": 800,
-      "height": 600,
-      "messages": []
-    }
+  "panel": {
+    "frame": "panel/panel.html",
+    "type": "dockable",
+    "title": "Simple",
+    "width": 800,
+    "height": 600,
+    "messages": []
   }
 }

--- a/test/fixtures/packages/needs-build/panel/panel.html
+++ b/test/fixtures/packages/needs-build/panel/panel.html
@@ -13,7 +13,7 @@
   </template>
 
   <script>
-    Editor.registerPanel( 'demo-simple.panel', {
+    Editor.polymerPanel( 'demo-simple', {
     });
   </script>
 </dom-module>

--- a/test/fixtures/packages/package-deps/package.json
+++ b/test/fixtures/packages/package-deps/package.json
@@ -4,7 +4,7 @@
   "description": "A Simple Package Test Fixture",
   "author": "Firebox Technology",
   "main": "main.js",
-  "pkgDependencies": {
+  "packages": {
     "dep-01": "0.0.1"
   }
 }

--- a/test/fixtures/packages/package-json-broken/package.json
+++ b/test/fixtures/packages/package-json-broken/package.json
@@ -9,16 +9,14 @@
       "message": "demo-simple:open"
     }
   },
-  "panels": {
-    "panel": {
-      "frame": "panel/panel.html",
-      "type": "dockable",
-      "title": "Simple",
-      "width": 800,
-      "height": 600,
-      "messages": [
-      ]
-    }
-  },
+  "panel": {
+    "frame": "panel/panel.html",
+    "type": "dockable",
+    "title": "Simple",
+    "width": 800,
+    "height": 600,
+    "messages": [
+    ]
+  }
   I am broken
 }

--- a/test/fixtures/packages/panel-ipc/package.json
+++ b/test/fixtures/packages/panel-ipc/package.json
@@ -4,16 +4,14 @@
   "description": "A Simple Package Test Fixture",
   "author": "Firebox Technology",
   "main": "main.js",
-  "panels": {
-    "panel": {
-      "frame": "panel/panel.html",
-      "type": "dockable",
-      "title": "panel-ipc",
-      "width": 800,
-      "height": 600,
-      "messages": [
-        "foobar:simple"
+  "panel": {
+    "frame": "panel/panel.html",
+    "type": "dockable",
+    "title": "panel-ipc",
+    "width": 800,
+    "height": 600,
+    "messages": [
+      "foobar:simple"
       ]
-    }
   }
 }

--- a/test/fixtures/packages/panel-ipc/panel/panel.html
+++ b/test/fixtures/packages/panel-ipc/panel/panel.html
@@ -13,7 +13,7 @@
   </template>
 
   <script>
-    Editor.registerPanel( 'panel-ipc.panel', {
+    Editor.polymerPanel( 'panel-ipc', {
       'foobar:simple' ( event, foo, bar ) {
         event.sender.send('foobar:reply', foo, bar);
       }

--- a/test/fixtures/packages/simple/package.json
+++ b/test/fixtures/packages/simple/package.json
@@ -9,15 +9,13 @@
       "message": "demo-simple:open"
     }
   },
-  "panels": {
-    "panel": {
-      "frame": "panel/panel.html",
-      "type": "dockable",
-      "title": "Simple",
-      "width": 800,
-      "height": 600,
-      "messages": [
-      ]
-    }
+  "panel": {
+    "frame": "panel/panel.html",
+    "type": "dockable",
+    "title": "Simple",
+    "width": 800,
+    "height": 600,
+    "messages": [
+    ]
   }
 }

--- a/test/fixtures/packages/simple/panel/panel.html
+++ b/test/fixtures/packages/simple/panel/panel.html
@@ -13,7 +13,7 @@
   </template>
 
   <script>
-    Editor.registerPanel( 'demo-simple.panel', {
+    Editor.polymerPanel( 'demo-simple', {
     });
   </script>
 </dom-module>

--- a/test/live/layout-demo/panel/simple-view.html
+++ b/test/live/layout-demo/panel/simple-view.html
@@ -48,7 +48,7 @@
 
 <script>
 Editor.easyRegister = function ( panelID, elementID ) {
-    Editor.registerPanel( panelID, {
+    Editor.polymerPanel( panelID, {
         is: elementID,
 
         listeners: {

--- a/test/main/ipc-panel.js
+++ b/test/main/ipc-panel.js
@@ -32,7 +32,7 @@ describe('Editor.IpcListener Panel', function () {
 
         // TODO: Panel.open should have callback
         setTimeout(() => {
-          Editor.Ipc.sendToPanel('panel-ipc.panel', 'foobar:simple', 'foo', 'bar');
+          Editor.Ipc.sendToPanel('panel-ipc', 'foobar:simple', 'foo', 'bar');
         }, 500);
       });
 

--- a/test/main/package-build.js
+++ b/test/main/package-build.js
@@ -70,7 +70,7 @@ describe('Editor.Package building test', function () {
 
         let packageInfo = Editor.Package.packageInfo(path);
         // let widgetInfo = Editor.Package.widgetInfo('simple-widget');
-        let panelInfo = Editor.Package.panelInfo('needs-build.panel');
+        let panelInfo = Editor.Package.panelInfo('needs-build');
 
         expect( packageInfo._path ).to.be.equal( path );
         expect( packageInfo._destPath ).to.be.equal( Path.join(path,'bin/dev') );


### PR DESCRIPTION
 - Fix console error stack will add main-process call stack when we raise a renderer process error
 - Add `Editor.Protocol.register` in renderer process
 - Add `deprecate` function in global and window
 - Add `Editor.trace` for trace log in main and renderer process
 - deprecate `pkgDependencies` in `package.json`, use `packages` instead
 - deprecate `panels` in `package.json`, use `panel` instead. for multiple panel registry, use `panel.x` for the additional panel.
 - deprecate `Editor.registerPanel`, use `Editor.polymerPanel` instead
 - deprecate `Editor.registerElement`, use `Editor.polymerElement` instead
