### PR TITLE
Update documentation on creating panels w/ examples

### DIFF
--- a/docs/packages/create-panels.md
+++ b/docs/packages/create-panels.md
@@ -4,7 +4,9 @@ In Editor-Framework, a `Panel` acts like a dockable "mini-window". Each panel co
 
 You can define a polymer element as your panel frame, and register it in `package.json`. Editor-Framework will dynamically then load your polymer element when the panel is opened.
 
-To define a panel frame, just create a javascript file like this:
+## Step 1: Define the main script for your panel 
+
+To define a panel frame, first create a javascript file like this (for instance in `panel/panel.js`):
 
 
 ```javascript
@@ -24,6 +26,60 @@ Editor.Panel.extend({
 });
 ```
 
+Available options to be passed to `extend` include:
+
+- `template` (string): Raw HTML to be rendered as contents of panel.
+- `style` (string): Raw CSS Styles to be accessible within panel 
+- `listeners` (object): Mapping for IPC message definitions and their respective callbacks. The callback function will be executed whenever it's matching key is received by this package's listener.      
+- `behaviors` (array): Array of behaviors predefined by Editor-Framework in `lib/ui/behaviors`. Behaviors define common  functionality for UI elements. Can be one of the following types:
+  - `Disable`
+  - `Dockable`
+  - `Droppable`
+  - `Focusable`
+  - `ReadOnly`
+  - `Resizable`
+  
+  Keep in mind Behaviors must be imported before they can be used. For example:
+  
+  ```javascript
+  // In panel/panel.js:
+  
+  const Focusable = require('editor-framework/lib/renderer/ui/behaviors/focusable');
+  const Dockable = require('editor-framework/lib/renderer/ui/behaviors/dockable');
+  
+  Editor.Panel.extend({
+    // ...
+    behaviors: [Focusable, Dockable],  // Or any others you'd like to add
+    /// ...
+  });
+  
+  
+  ```
+- `$` (array of strings): List of DOM IDs within your template which will be stored in the selectors object (`$`). 
+For example, if your template HTML contained a selector `<span id="my_title">Title</span>`, then could access its DOM node from 
+the code code using `$.my_title`:
+ 
+  ```javascript
+  // In panel/panel.js:
+  Editor.Panel.extend({
+    //...
+    
+    template: <div><span id="my_title">Title</span></div>
+    $: ["my_title"],
+      
+    /// ...
+  });
+  
+  // In panel initializer:
+  init ( panel ) {
+    let myTitleElm = panel.$.my_title;
+    // ...
+  },
+  ```
+   
+
+## Step 2: Add the panel definition to your package.json
+
 Then save it to your package's `panel` field. After that register the html file in `package.json`:
 
 ```json
@@ -39,9 +95,11 @@ Then save it to your package's `panel` field. After that register the html file 
 }
 ```
 
+## Step 3: Opening the panel:
+
 Once your package is loaded, you can use `Editor.Panel.open('simple')` to open your panel. Note that the argument passed to `Editor.Panel.open` corresponds to the `name` field in the package's JSON definition.
 
-## Panel ID
+### Panel ID
 
 A panelID is a string of the format `{package-name}.{sub-name}`. It is used in most of the functions in `Editor.Panel` that need to operate on a specific panel.
 
@@ -61,7 +119,7 @@ Suppose we have the following `package.json` file:
 
 The file registers two panels `panel` and `panel.02`, which correspond to the two `panelID`s `foo` and `foo.02`.
 
-## Options
+## Additional `package.json` Options
 
  - `main`: String (path) - Panel's main entry file.
  - `type`: String - Panel's type, can be `'dockable'`, `'float'`, `'fixed-size'`, `'quick'` and `'simple'`. Default is `'dockable'`
@@ -74,34 +132,79 @@ The file registers two panels `panel` and `panel.02`, which correspond to the tw
  - `max-width` Integer - Panel window’s maximum width.
  - `max-height` Integer - Panel window’s maximum height.
 
-## Register Template
+## Registering a Template
 
 Template HTML can be defined within the panel's main JS file (eg `package-name/panel/panel.js`).
 
 *TODO: Expand Example*
 
-## Register Style
+## Registering Styles
 
 TODO:
 
-## Register Behaviors
+## Registering Behaviors
 
 TODO:
 
-## Register Selectors ($)
+## Registering Selectors ($)
 
 TODO:
 
-## Register Ipc Messages
+## Registering Ipc Messages
 
 TODO:
 
-## Register Shortcuts
+## Registering Shortcuts
 
 TODO:
 
-## Register Profiles
+## Registering Profiles
 
 TODO:
 
 ## Example panel.js file:
+
+```javascript
+'use strict';
+
+const Focusable = require('editor-framework/lib/renderer/ui/behaviors/focusable');
+
+Editor.Panel.extend({
+  style: `
+    h1 {
+      color: #09f;
+    }
+  `,
+
+  template: `
+    <h1 id="my_title">This is just a panel with a title</h1>
+  `,
+
+  listeners: {
+    click ( event ) {
+      event.stopPropagation();
+      console.log('click!');
+    },
+
+    'panel-resize' ( event ) {
+      console.log(event.target);
+    },
+  },
+
+  behaviors: [ Focusable ],
+
+  $: ["my_title"],
+
+  ready () {
+  },
+  
+  init(panel) {
+    console.log(`Initialized Panel with title elm`,  panel.$.my_title);
+  },
+
+  run (argv) {
+    
+  },
+});
+
+```

--- a/docs/packages/create-panels.md
+++ b/docs/packages/create-panels.md
@@ -31,30 +31,6 @@ Available options to be passed to `extend` include:
 - `template` (string): Raw HTML to be rendered as contents of panel.
 - `style` (string): Raw CSS Styles to be accessible within panel 
 - `listeners` (object): Mapping for IPC message definitions and their respective callbacks. The callback function will be executed whenever it's matching key is received by this package's listener.      
-- `behaviors` (array): Array of behaviors predefined by Editor-Framework in `lib/ui/behaviors`. Behaviors define common  functionality for UI elements. Can be one of the following types:
-  - `Disable`
-  - `Dockable`
-  - `Droppable`
-  - `Focusable`
-  - `ReadOnly`
-  - `Resizable`
-  
-  Keep in mind Behaviors must be imported before they can be used. For example:
-  
-  ```javascript
-  // In panel/panel.js:
-  
-  const Focusable = require('editor-framework/lib/renderer/ui/behaviors/focusable');
-  const Dockable = require('editor-framework/lib/renderer/ui/behaviors/dockable');
-  
-  Editor.Panel.extend({
-    // ...
-    behaviors: [Focusable, Dockable],  // Or any others you'd like to add
-    /// ...
-  });
-  
-  
-  ```
 - `$` (array of strings): List of DOM IDs within your template which will be stored in the selectors object (`$`). 
 For example, if your template HTML contained a selector `<span id="my_title">Title</span>`, then could access its DOM node from 
 the code code using `$.my_title`:
@@ -64,15 +40,19 @@ the code code using `$.my_title`:
   Editor.Panel.extend({
     //...
     
-    template: <div><span id="my_title">Title</span></div>
-    $: ["my_title"],
+    template: `
+      <div><span id="my_title">Title</span></div>
+    `,
+    $: {
+      my_title: "#my_title"
+    },
       
     /// ...
   });
   
   // In panel initializer:
   init ( panel ) {
-    let myTitleElm = panel.$.my_title;
+    let myTitleElm = panel.$my_title;
     // ...
   },
   ```
@@ -191,15 +171,15 @@ Editor.Panel.extend({
     },
   },
 
-  behaviors: [ Focusable ],
-
-  $: ["my_title"],
+  $: {
+    my_title: "#my_title"
+  },
 
   ready () {
   },
   
   init(panel) {
-    console.log(`Initialized Panel with title elm`,  panel.$.my_title);
+    console.log(`Initialized Panel with title elm`,  panel.$my_title);
   },
 
   run (argv) {


### PR DESCRIPTION
- Added object arguments for `Editor.Panel.extend`
- Added an example