### PR TITLE
fix restore focus panel will raise error when panel is not existed

### DIFF
--- a/lib/renderer/ui/utils/focus-mgr.js
+++ b/lib/renderer/ui/utils/focus-mgr.js
@@ -183,6 +183,11 @@ FocusMgr._setFocusPanelFrame = function ( panelFrame ) {
 FocusMgr._restoreFocusPanel = function () {
   if ( _focusedPanelFrame ) {
     let panel = _focusedPanelFrame.parentElement;
+    if ( !panel ) {
+      FocusMgr._setFocusPanelFrame(null);
+      return;
+    }
+
     panel._setFocused(true);
 
     // NOTE: if we have focused element, skip focus panel frame


### PR DESCRIPTION
update cocos-creator/fireball#3692